### PR TITLE
Fixed - sans-serif font family not available in iOS

### DIFF
--- a/src/theme/typography.js
+++ b/src/theme/typography.js
@@ -1,6 +1,7 @@
+import { Platform } from 'react-native';
 import colors from './colors';
 
-const fontFamily = 'sans-serif';
+const fontFamily = Platform.select({ android: 'sans-serif', ios: 'Helvetica' });
 const fontWeightRegular = 'normal';
 const fontWeightSemiBold = '600';
 const fontWeightBold = 'bold';


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
sans-serif font family is not available in iOS, so app will crash.

**Does this close any currently open issues?**
close #56 

**Screenshots**
If applicable, add screenshots of end result.

**Any other comments?**

**Where has this been tested?**
---------------------------
 - Magento Version: [e.g. 2.1.0]
 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Version [e.g. 22]
