### PR TITLE
fix: Category Grid Item not rendering properly

### DIFF
--- a/src/components/product/CatalogGrid/CatalogGrid.js
+++ b/src/components/product/CatalogGrid/CatalogGrid.js
@@ -75,6 +75,7 @@ const CatalogGrid = ({
 
   const renderRow = ({ item }) => (
     <CatalogGridItem
+      columnCount={columnCount}
       product={item}
       stateAccessor={stateAccessor}
       updateItem={updateItem}

--- a/src/components/product/CatalogGridItem/CatalogGridItem.js
+++ b/src/components/product/CatalogGridItem/CatalogGridItem.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Dimensions } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import NavigationService from '../../../navigation/NavigationService';
@@ -15,6 +15,10 @@ import { ThemeContext } from '../../../theme';
 import { ProductType } from '../../../types';
 
 const CatalogGridItem = ({
+/**
+   * No of colums to  dispaly
+   */
+  columnCount,
   /**
    * Product to dispaly
    */
@@ -81,7 +85,7 @@ const CatalogGridItem = ({
   return (
     <Card
       type="outline"
-      style={styles.container(theme)}
+      style={styles.container(theme,columnCount)}
       onPress={onItemPress}
     >
       <Image
@@ -98,8 +102,8 @@ const CatalogGridItem = ({
 };
 
 const styles = StyleSheet.create({
-  container: theme => ({
-    width: theme.dimens.catalogGridItemWidth,
+  container: (theme, columnCount) => ({
+    width: columnCount > 1 ? theme.dimens.WINDOW_WIDTH / columnCount : theme.dimens.catalogGridItemWidth,
     height: theme.dimens.catalogGridItemHeight,
   }),
   imageStyle: theme => ({

--- a/src/theme/dimens.js
+++ b/src/theme/dimens.js
@@ -1,7 +1,12 @@
+import { Dimensions } from 'react-native';
+const screenWidth = Dimensions.get('window').width;
+const screenHeight = Dimensions.get('window').height;
 export default {
   /**
    * App level constants
    */
+  WINDOW_WIDTH: screenWidth,
+  WINDOW_HEIGHT: screenHeight,
   borderRadius: 2,
   catalogGridItemWidth: 150,
   catalogGridItemHeight: 200,


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
Grid list now send the Column Count to GridItem. And then in GridItem the width is set according to Column Count. `width=width of screen/coloumncount`

**Does this close any currently open issues?**
close #68

**Screenshots**
![Simulator Screen Shot - iPhone 11 - 2019-10-31 at 13 43 51](https://user-images.githubusercontent.com/32247358/67929919-92788d00-fbe4-11e9-9c35-9720c2256a4e.png)

**Where has this been tested?**
---------------------------
 - Magento Version: [2.1.0]
 - Device: [iPhone 11]
 - OS: [iOS 13]

